### PR TITLE
Err VS2015: Redeclaration proc info size

### DIFF
--- a/Hidden/PsTable.c
+++ b/Hidden/PsTable.c
@@ -106,7 +106,7 @@ NTSTATUS InitializeProcessTable(VOID(*InitProcessEntryCallback)(PProcessTableEnt
 		CLIENT_ID clientId;
 		OBJECT_ATTRIBUTES attribs;
 		HANDLE hProcess;
-		SIZE_T size;
+		//SIZE_T size;
 
 		// Get process path
 


### PR DESCRIPTION
Hello!  Redeclaration in process information length (SIZE_T size) make troubles with building solution on VS2015, commenting trouble line - make compilation project great again :)
Thank you for attention, with best regards.